### PR TITLE
Fix problematic naive query splitting

### DIFF
--- a/fast_sql.go
+++ b/fast_sql.go
@@ -178,9 +178,18 @@ func (in *insert) splitQuery(query string) {
 	)
 
 	// Split query
-	ndxValues = valuesRegexp.FindStringIndex(query)[0]
+	valuesMatches := valuesRegexp.FindStringIndex(query)
+	if len(valuesMatches) == 0 {
+		ndxValues = -1
+	} else {
+		ndxValues = valuesMatches[0]
+	}
 	dupeMatches := dupeRegexp.FindAllStringIndex(query, -1)
-	ndxOnDupe = dupeMatches[len(dupeMatches)-1][0]
+	if len(dupeMatches) == 0 {
+		ndxOnDupe = -1
+	} else {
+		ndxOnDupe = dupeMatches[len(dupeMatches)-1][0]
+	}
 	ndxParens = strings.LastIndex(query, ")")
 
 	// Split out first part of query


### PR DESCRIPTION
The original `splitQuery` function naively changed the case of the entire query to lower -- this is problematic for many reasons, chief of which being that MySQL table names in *nix environments are case sensitive.  Instead of incorrectly sending the entire query to lower case, it's safer to search for your string offsets with case insensitive regular expressions.
