### PR TITLE
Fix db close causes sql syntax error when flushing empty batched inserts

### DIFF
--- a/fast_sql.go
+++ b/fast_sql.go
@@ -114,6 +114,9 @@ func (d *DB) BatchInsert(query string, params ...interface{}) (err error) {
 // FlushAll iterates over all batch inserts and inserts them into the database.
 func (d *DB) FlushAll() error {
 	for _, in := range d.batchInserts {
+		if in.insertCtr <= 0 {
+			continue
+		}
 		if err := d.flushInsert(in); err != nil {
 			return err
 		}


### PR DESCRIPTION
When the database close, ```FlushAll``` will be called, causing the following to be ran:

```
for _, in := range d.batchInserts {
  if err := d.flushInsert(in); err != nil {
    return err
  }
}
```

If the ```in``` does not contain any pending inserts, the following error will be thrown:

```
Error 1064: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '' at line 1
```

Due to the way query is constructed. Therefore, we can simply just ignore ```in``` with no more pending inserts.